### PR TITLE
34 add pr checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,46 +1,21 @@
-<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
+> [!CAUTION]
+> You're merging to **ros-navigation/navigation2** repository by default!
+> Remember to change your **base repository** to **hsrn24/navigation2**
 
----
+## Dependencies
+- *Optional: Related robo_cart_marc5 PR*
+- Fixes #
 
-## Basic Info
+## Description
+This PR introduces following changes:
+-
 
-| Info | Please fill out this column |
-| ------ | ----------- |
-| Ticket(s) this addresses   | (add tickets here #1) |
-| Primary OS tested on | (Ubuntu, MacOS, Windows) |
-| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
+## Checklist
+- [ ] **navigation.yaml** from **robo_cart_marc5** repo aligned
+- [ ] Changes will work on both **5470** & **5475** versions of the cart
+- [ ] New code formatted with **Clang-Format** (VSC task: **Ctrl+Shift+i**)
+> [!WARNING]
+> Don't reformat existing code, we don't want revolution against upstream
+- [ ] **README** (or other docs) updated
+- [ ] Tested on the cart
 
----
-
-## Description of contribution in a few bullet points
-
-<!--
-* I added this neat new feature
-* Also fixed a typo in a parameter name in nav2_costmap_2d
--->
-
-## Description of documentation updates required from your changes
-
-<!--
-* Added new parameter, so need to add that to default configs and documentation page
-* I added some capabilities, need to document them
--->
-
----
-
-## Future work that may be required in bullet points
-
-<!--
-* I think there might be some optimizations to be made from STL vector
-* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
-* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
--->
-
-#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
-- [ ] Check that any new parameters added are updated in navigation.ros.org
-- [ ] Check that any significant change is added to the migration guide
-- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
-- [ ] Check that any new functions have Doxygen added
-- [ ] Check that any new features have test coverage
-- [ ] Check that any new plugins is added to the plugins page
-- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists


### PR DESCRIPTION
> [!CAUTION]
> You're merging to **ros-navigation/navigation2** repository by default!
> Remember to change your **base repository** to **hsrn24/navigation2**

## Dependencies
- *Optional: Related robo_cart_marc5 PR*
- Fixes #34

## Description
This PR introduces following changes:
- PR template updated to what you see

## Checklist
- [ ] **navigation.yaml** from **robo_cart_marc5** repo aligned
- [ ] Changes will work on both **5470** & **5475** versions of the cart
- [ ] New code formatted with **Clang-Format** (VSC task: **Ctrl+Shift+i**)
> [!WARNING]
> Don't reformat existing code, we don't want revolution against upstream
- [ ] **README** (or other docs) updated
- [ ] Tested on the cart

