### PR TITLE
Added reset_if_moved to SaveTravelledPath bt leaf

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/save_travelled_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/save_travelled_path_action.hpp
@@ -26,7 +26,7 @@ namespace nav2_behavior_tree
  * and, effectively, the accuracy with which the tail of the path tracks
  * max_distance.
  *
- * Calling this node with max_distance = 0.0 clears the recorded path
+ * Calling this node with max_distance <= 0.0 clears the recorded path
  * (only the current pose remains), unless reset_if_moved > 0.0 and the robot
  * is still within that distance of the last recorded pose, in which case the
  * existing trail is reused instead of cleared.

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/save_travelled_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/save_travelled_path_action.hpp
@@ -27,7 +27,9 @@ namespace nav2_behavior_tree
  * max_distance.
  *
  * Calling this node with max_distance = 0.0 clears the recorded path
- * (only the current pose remains).
+ * (only the current pose remains), unless reset_if_moved > 0.0 and the robot
+ * is still within that distance of the last recorded pose, in which case the
+ * existing trail is reused instead of cleared.
  *
  * Returns BT::NodeStatus::SUCCESS unless the current robot pose cannot be
  * obtained (FAILURE).
@@ -62,6 +64,11 @@ public:
       BT::InputPort<double>(
         "resolution", 0.1,
         "Minimum spacing between consecutive samples on the backup path"),
+      BT::InputPort<double>(
+        "reset_if_moved", 0.0,
+        "In reset mode (max_distance <= 0.0), only clear the trail if the robot "
+        "moved more than this many meters from the last recorded pose; otherwise "
+        "reuse the existing trail. 0.0 (default) always clears."),
       BT::InputPort<std::string>(
         "global_frame", std::string("map"), "Global frame"),
       BT::InputPort<std::string>(

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -238,6 +238,7 @@
       <output_port name="path">The path covered by the robot over the last max_distance meters (bidirectional port)</output_port>
       <input_port name="max_distance">Length of the recorded backup path behind the robot</input_port>
       <input_port name="resolution">Minimum spacing between consecutive samples on the backup path</input_port>
+      <input_port name="reset_if_moved">In reset mode (max_distance &lt;= 0.0), only clear the trail if the robot moved more than this many meters from the last recorded pose; otherwise reuse the existing trail. 0.0 (default) always clears.</input_port>
       <input_port name="global_frame">Reference frame to check in</input_port>
       <input_port name="robot_frame">Robot frame to check relative to global_frame</input_port>
     </Action>

--- a/nav2_behavior_tree/plugins/action/save_travelled_path_action.cpp
+++ b/nav2_behavior_tree/plugins/action/save_travelled_path_action.cpp
@@ -60,8 +60,18 @@ inline BT::NodeStatus SaveTravelledPathAction::tick()
     return BT::NodeStatus::SUCCESS;
   }
 
-  // Reset: max_distance == 0.0 clears the buffer, keeping only the current pose
+  // Reset: max_distance <= 0.0 clears the buffer, keeping only the current pose.
+  // If reset_if_moved > 0.0, keep the existing trail when the robot is still
+  // within that distance of the last recorded pose (e.g. a new goal issued from
+  // roughly the same spot), so the accumulated backup path is not thrown away.
   if (max_distance_ <= 0.0) {
+    double reset_if_moved = 0.0;
+    getInput("reset_if_moved", reset_if_moved);
+    if (reset_if_moved > 0.0 && !poses.empty() &&
+      dist_to_last_saved_pose <= reset_if_moved)
+    {
+      return BT::NodeStatus::SUCCESS;
+    }
     poses.clear();
     poses.emplace_back(current_pose);
   } else {


### PR DESCRIPTION
> [!CAUTION]
> You're merging to **ros-navigation/navigation2** repository by default!
> Remember to change your **base repository** to **hsrn24/navigation2**

## Dependencies
- *Optional: Related robo_cart_marc5 PR*
- Fixes #

## Description
This PR introduces following changes:
-

## Checklist
- [ ] **navigation.yaml** from **robo_cart_marc5** repo aligned
- [ ] Changes will work on both **5470** & **5475** versions of the cart
- [ ] New code formatted with **Clang-Format** (VSC task: **Ctrl+Shift+i**)
> [!WARNING]
> Don't reformat existing code, we don't want revolution against upstream
- [ ] **README** (or other docs) updated
- [ ] Tested on the cart

