### PR TITLE
Ensure a valid path is always provided to truncate path local

### DIFF
--- a/nav2_behavior_tree/CMakeLists.txt
+++ b/nav2_behavior_tree/CMakeLists.txt
@@ -229,6 +229,9 @@ list(APPEND plugin_libs nav2_goal_updated_controller_bt_node)
 add_library(nav2_is_pose_away_condition_bt_node SHARED plugins/condition/is_pose_away_condition.cpp)
 list(APPEND plugin_libs nav2_is_pose_away_condition_bt_node)
 
+add_library(nav2_is_blackboard_true_condition_bt_node SHARED plugins/condition/is_blackboard_true_condition.cpp)
+list(APPEND plugin_libs nav2_is_blackboard_true_condition_bt_node)
+
 add_library(nav2_print_log_bt_node SHARED plugins/action/print_log_node.cpp)
 list(APPEND plugin_libs nav2_print_log_bt_node)
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_directional_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/back_up_directional_action.hpp
@@ -60,7 +60,7 @@ public:
         BT::InputPort<double>("backup_dist", 0.15, "Distance to backup"),
         BT::InputPort<double>("backup_speed", 0.025, "Speed at which to backup"),
         BT::InputPort<double>("time_allowance", 10.0, "Allowed time for reversing"),
-        BT::InputPort<nav_msgs::msg::Path>("truncated_path", "Truncated local path which should be shortened to the desired search distance")
+        BT::InputPort<nav_msgs::msg::Path>("travelled_path", "Travelled path (behind the robot) whose far end sets the backup direction")
       });
   }
 private:

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_blackboard_true_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_blackboard_true_condition.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 MuLTechnologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "behaviortree_cpp_v3/condition_node.h"
+
+namespace nav2_behavior_tree
+{
+
+/**
+ * @brief A BT::ConditionNode that returns SUCCESS when the given boolean
+ * blackboard value is true, FAILURE otherwise
+ */
+class IsBlackboardTrue : public BT::ConditionNode
+{
+public:
+  IsBlackboardTrue(const std::string & condition_name, const BT::NodeConfiguration & conf)
+  : BT::ConditionNode(condition_name, conf)
+  {
+  }
+
+  IsBlackboardTrue() = delete;
+
+  BT::NodeStatus tick() override;
+
+  static BT::PortsList providedPorts()
+  {
+    return {
+      BT::InputPort<bool>("value", false, "Blackboard boolean value to check")
+    };
+  }
+};
+
+}  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -314,6 +314,10 @@
       <input_port name="distance">Distance threshold </input_port>
     </Condition>
 
+    <Condition ID="IsBlackboardTrue">
+      <input_port name="value">Blackboard boolean value to check</input_port>
+    </Condition>
+
     <!-- ############################### CONTROL NODES ################################ -->
     <Control ID="PipelineSequence"/>
 

--- a/nav2_behavior_tree/plugins/action/back_up_directional_action.cpp
+++ b/nav2_behavior_tree/plugins/action/back_up_directional_action.cpp
@@ -33,11 +33,10 @@ BackUpDirectionalAction::BackUpDirectionalAction(
   double time_allowance;
   getInput("time_allowance", time_allowance);
 
-  // Populate the input message
   goal_.target.x = dist;
   goal_.target.y = 0.0;
   goal_.target.z = 0.0;
-  goal_.speed = speed; // The base speed is positive which will ensure regular backup
+  goal_.speed = speed;
   goal_.time_allowance = rclcpp::Duration::from_seconds(time_allowance);
 
   tf_buffer_ =
@@ -50,22 +49,33 @@ BackUpDirectionalAction::BackUpDirectionalAction(
 void BackUpDirectionalAction::on_tick()
 {
   nav_msgs::msg::Path path;
-  getInput("truncated_path", path);
+  getInput("travelled_path", path);
 
-  geometry_msgs::msg::PoseStamped reference_pose = path.poses.back();
+  // BackUp negates goal_.speed before driving (linear.x = -goal_.speed), so a
+  // positive goal_.speed drives -x (reverse) and a negative one drives +x.
+  const double speed_mag = std::fabs(goal_.speed);
+
+  if (path.poses.empty()) {
+    RCLCPP_WARN(node_->get_logger(), "[BackUpDirectionalAction] Empty path; failing.");
+    should_send_goal_ = false;
+    return;
+  }
+
+  // Reference is the far (oldest) end of the trail: the point behind the robot.
+  geometry_msgs::msg::PoseStamped reference_pose = path.poses.front();
   reference_pose.header.frame_id = path.header.frame_id;
-  // Using time now as here we take the global plan as input which often is a few seconds old and throws an error on timestamp
+  // Freshly stamp so the tf lookup below does not trip the timestamp tolerance.
   reference_pose.header.stamp = node_->now();
 
   geometry_msgs::msg::PoseStamped transformed_pose;
 
   nav2_util::transformPoseInTargetFrame(reference_pose, transformed_pose, *tf_buffer_, "base_link", 1.0);
 
-  if (transformed_pose.pose.position.x >= 0) {
-    goal_.speed = std::fabs(goal_.speed);
-  } else {
-    goal_.speed = -std::fabs(goal_.speed);
-  }
+  const double ref_x = transformed_pose.pose.position.x;
+
+  // Back up TOWARD the reference behind the robot. goal_.speed > 0 => reverse,
+  // < 0 => forward (see note above).
+  goal_.speed = (ref_x >= 0.0) ? -speed_mag : speed_mag;
 
   RCLCPP_INFO_STREAM(node_->get_logger(), "[BackUpDirectionalAction] Speed: " << goal_.speed);
 

--- a/nav2_behavior_tree/plugins/condition/is_blackboard_true_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_blackboard_true_condition.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 MuLTechnologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nav2_behavior_tree/plugins/condition/is_blackboard_true_condition.hpp"
+
+namespace nav2_behavior_tree
+{
+
+BT::NodeStatus IsBlackboardTrue::tick()
+{
+  bool value = false;
+  getInput("value", value);
+  return value ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
+}
+
+}  // namespace nav2_behavior_tree
+
+#include "behaviortree_cpp_v3/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<nav2_behavior_tree::IsBlackboardTrue>("IsBlackboardTrue");
+}


### PR DESCRIPTION
> [!CAUTION]
> You're merging to **ros-navigation/navigation2** repository by default!
> Remember to change your **base repository** to **hsrn24/navigation2**

## Dependencies
- *Optional: Related robo_cart_marc5 PR*
- Fixes #

## Description
This PR introduces following changes:
-

## Checklist
- [ ] **navigation.yaml** from **robo_cart_marc5** repo aligned
- [ ] Changes will work on both **5470** & **5475** versions of the cart
- [ ] New code formatted with **Clang-Format** (VSC task: **Ctrl+Shift+i**)
> [!WARNING]
> Don't reformat existing code, we don't want revolution against upstream
- [ ] **README** (or other docs) updated
- [ ] Tested on the cart

